### PR TITLE
Add processing ratio metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+## 0.2.0 (Unreleased)
+
+#### Added
+
+* Add `resque_processing_ratio` metric.
+
+#### Changed
+
+* Rename the repository to resque-exporter.
+
+## 0.1.0
+
+* Initial release.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Intellection/devops

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ You can deploy the resque exporter using the [zappi/resque-exporter](https://hub
 | resque\_job\_executions\_total | Total number of job executions. | |
 | resque\_jobs\_in\_failed\_queue | Number of jobs in a failed queue. | queue |
 | resque\_jobs\_in\_queue | Number of jobs in a queue. | queue |
+| resque\_processing\_ratio | Ratio of queued jobs to workers processing those queues. | queue |
 | resque\_scrape\_duration\_seconds | Time this scrape of resque metrics took. | |
 | resque\_scrapes\_total | Total number of scrapes. | |
 | resque\_up | Whether this scrape of resque metrics was successful. | |


### PR DESCRIPTION
Adds a new metric called `resque_processing_ratio` which is a ratio of the number of queued jobs to the number of workers handling those queues.

This metric is very useful for horizontally scaling resque workers where each worker handles a specific queue, or all workers handle all queues. It can get a bit fuzzy when workers share some but not all queues.

**Why is this metric better than queue size?**

Scaling only on queue size can lead to undesirable scaling behaviour, such as extreme thrashing. This happens because the current number of workers is not taken into consideration when evaluating how much capacity is required to handle the queue. 

**Example**

First, some assumptions:
* We're using the Kubernetes' [HPA scaling algorithm](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#algorithm-details):
    ```
    desired_replicas = current_replicas * ( current_metric_value / desired_metric_value )
    ```
* The processing ratio is calculated as follows:
   ```
   processing_ratio = jobs_queued / worker_count
   ```
* We have only one queue.
* We have a minimum of two workers for the queue.
* We have the following scaling targets:
  * For processing ratio, we want a value of 1.
  * For number of jobs queued, we want a value of 1.

Scenario 1:
```yaml
worker_count: 2
jobs_queued: 0
processing_ratio: 0 / 2 = 0
desired_replicas_for_jobs_queued: 2 * (0 / 1) = 2
desired_replicas_for_processing_ratio: 2 * (0 / 1) = 2
```

Scenario 2:
```yaml
worker_count: 2
jobs_queued: 50
processing_ratio: 50 / 2 = 25
desired_replicas_for_jobs_queued: 2 * (50 / 1) = 100
desired_replicas_for_processing_ratio: 2 * (25 / 1) = 50
```

Scenario 3:
```yaml
worker_count: 5
jobs_queued: 50
processing_ratio: 50 / 5 = 10
desired_replicas_for_jobs_queued: 5 * (50 / 1) = 250
desired_replicas_for_processing_ratio: 5 * (10 / 1) = 50
```

Scenario 4:
```yaml
worker_count: 10
jobs_queued: 25
processing_ratio: 25 / 10 = 2.5
desired_replicas_for_jobs_queued: 10 * (25 / 1) = 250
desired_replicas_for_processing_ratio: 10 * (2.5 / 1) = 25
```

In these scenarios, you can see just how aggressive scaling on queue would be, while scaling on processing ratio attempts to maintain a`1:1` ratio of job to workers. 

Even a `1:1` ratio can be seen as too aggressive, you may even want to incorporate a scaling factor to achieve `2:1`.