### PR TITLE
Change user/group to nobody:nogroup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.3.0
+
+#### Changed
+
+* Run as user `nobody` and group `nogroup` instead of `root`.
+
 ## 0.2.2
 
 #### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,7 @@ MAINTAINER Satoshi Matsumoto <kaorimatz@gmail.com>
 
 COPY --from=builder /resque-exporter /bin/resque-exporter
 
+USER nobody:nogroup
+
 EXPOSE 9447
 ENTRYPOINT ["/bin/resque-exporter"]


### PR DESCRIPTION
Because we don't need to run as `root`. To note the UID of `nobody` is `65534` and the GID of `nogroup` is `65534`. The `quay.io/prometheus/busybox` image already has a `nobody` user and a `nogroup` group. See below:

```console
$ docker run -it quay.io/prometheus/busybox
/ # awk -F: '{printf "%s:%s\n",$1,$3}' /etc/passwd
root:0
daemon:1
bin:2
sys:3
sync:4
mail:8
www-data:33
operator:37
nobody:65534

/ # cat /etc/group
root:x:0:
daemon:x:1:
bin:x:2:
sys:x:3:
adm:x:4:
tty:x:5:
disk:x:6:
lp:x:7:
mail:x:8:
kmem:x:9:
wheel:x:10:root
cdrom:x:11:
dialout:x:18:
floppy:x:19:
video:x:28:
audio:x:29:
tape:x:32:
www-data:x:33:
operator:x:37:
utmp:x:43:
plugdev:x:46:
staff:x:50:
lock:x:54:
netdev:x:82:
users:x:100:
nogroup:x:65534:
```